### PR TITLE
Bump build number to rebuild for long prefix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   md5: {{ md5 }}
 
 build:
-  number: 0
+  number: 1
 
   entry_points:
     - coverage = coverage.cmdline:main


### PR DESCRIPTION
Appears that there are some hard coded paths. This bumps the build number to ensure that the other Python versions (2.7 and 3.5) are using the long prefix from `conda-build` 2.