### PR TITLE
fix: Add tomli dependency back again.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   entry_points:
     - coverage = coverage.cmdline:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - pip
   run:
     - python
-    - tomli
+    # extra dependency
+    - tomli  
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pip
   run:
     - python
+    - tomli
 
 test:
   requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
While using colcon to build our workspace we encountered the following issue:
```
The 'tomli; extra == "toml"' distribution was not found and is required by coverage
```
Following the issue we found that tomli was not installed anymore since `v6.3.2` but this was no change on the pip package so we found that it was the change in the recipe of the `v6.3.2` release.
